### PR TITLE
v1.5.0 for Fedora 27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
     - DOCKER_IMAGE=alectolytic/rpmbuilder
     - OS_ARCH=x86_64
   matrix:
-    - OS_TYPE=fedora OS_DIST=fedora OS_VERSION=25 COPR_REPOSITORY=repository
-    - OS_TYPE=fedora OS_DIST=fedora OS_VERSION=25 COPR_REPOSITORY=ghostwriter
+    - OS_TYPE=fedora OS_DIST=fedora OS_VERSION=27 COPR_REPOSITORY=repository
+    - OS_TYPE=fedora OS_DIST=fedora OS_VERSION=27 COPR_REPOSITORY=ghostwriter
 
 services:
   - docker

--- a/ghostwriter.spec
+++ b/ghostwriter.spec
@@ -3,7 +3,7 @@
 
 Summary: ghostwriter: A cross-platform, aesthetic, distraction-free Markdown editor
 Name: ghostwriter
-Version: 1.4.2
+Version: 1.5.0
 Release: 1%{?dist}
 License: GPLv3+
 Group: Development/Tools
@@ -45,6 +45,9 @@ make install
 %doc COPYING CREDITS.md
 
 %changelog
+* Wed Feb 28 2018 Machiel Molenaar <machiel@machiel.me>
+- Version 1.5.0 for Fedora 27
+
 * Thu Dec 15 2016 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 1.4.2-1
 - Initial version v1.4.2
 


### PR DESCRIPTION
This should be enough to generate a package for copr for fedora 27, v1.5.0 of ghostwriter.